### PR TITLE
(fix) Set request headers for shard detection request

### DIFF
--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -479,16 +479,18 @@ export default class XmppConnection extends Listenable {
         // Debugging info for shard detection
         logger.info(`[REQUEST ${traceId}] GET ${url}`);
 
-        const decodedToken = this._decodeTokenFromKeepAliveAndCheckShardUrl(url);
-
-        const requestHeaders = {
+        const headers = {
             'Content-Type': 'application/json',
             'X-Trace-Id': traceId,
-            'X-User-Id': decodedToken ? decodedToken.uuid : 'NO_UUID'
         };
 
+        const decodedToken = this._decodeTokenFromKeepAliveAndCheckShardUrl(url);
+        if (decodedToken?.uuid) {
+            headers['X-User-Id'] = decodedToken?.uuid;
+        }
+
         // return fetch(url)
-        return fetch(url, requestHeaders)
+        return fetch(url, { headers })
 
         // #end
             .then(response => {


### PR DESCRIPTION
`headers` option of `fetch()` was not set correctly, so none of the headers were sent in the shard detection request.