### PR TITLE
fix(screenshare): sharing tab going fullscreen

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -230,8 +230,17 @@ const ScreenObtainer = {
         if (setScreenSharingResolutionConstraints && !(desktopSharingFrameRate?.max > SS_DEFAULT_FRAME_RATE)) {
             // Set bogus resolution constraints to work around
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311
-            video.height = 99999;
-            video.width = 99999;
+            // #bloomberg #screenshare @jabarca update "max" resolution to fix sharing tab in full screen mode.
+            // Happens when sharing Google Slides and going into slideshow. Seems like constraints are treated
+            // as max when capturing normally, but not when capturing fullscreened tab. Then the aspect ratio
+            // of the constraints is enforced, forcing vertical black bars on the sides (letterboxing). Setting
+            // constraints to 4x 4K resolution should be enough to cover all monitor sizes while preserving
+            // aspect ration in presentations. Other multiples of 4K seem not to have the desired effect of
+            // avoiding letterboxing.
+            // video.height = 99999;
+            // video.width = 99999;
+            video.height = 8640;
+            video.width = 15360;
         }
 
         const audio = this._getAudioConstraints();

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -230,17 +230,19 @@ const ScreenObtainer = {
         if (setScreenSharingResolutionConstraints && !(desktopSharingFrameRate?.max > SS_DEFAULT_FRAME_RATE)) {
             // Set bogus resolution constraints to work around
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311
+            
             // #bloomberg #screenshare @jabarca update "max" resolution to fix sharing tab in full screen mode.
             // Happens when sharing Google Slides and going into slideshow. Seems like constraints are treated
             // as max when capturing normally, but not when capturing fullscreened tab. Then the aspect ratio
             // of the constraints is enforced, forcing vertical black bars on the sides (letterboxing). Setting
             // constraints to 4x 4K resolution should be enough to cover all monitor sizes while preserving
-            // aspect ration in presentations. Other multiples of 4K seem not to have the desired effect of
+            // aspect ratio in presentations. Other multiples of 4K seem not to have the desired effect of
             // avoiding letterboxing.
             // video.height = 99999;
             // video.width = 99999;
             video.height = 8640;
             video.width = 15360;
+            // #end
         }
 
         const audio = this._getAudioConstraints();


### PR DESCRIPTION
Update screensharing resolution constraints to account for case when tab being shared is Google Slides presentation in full screen slideshow mode.
DRQS 170334609

**Testing performed**
Wrote test site and tried setting different resolution in constraints while sharing Google Slides.